### PR TITLE
Add `disabled` component option argument with streamlit appropriate styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,13 +27,16 @@ The `option_menu` function accepts the following parameters:
 - styles (optional, default=None): A dictionary containing the CSS definitions for most HTML elements in the menu, including:
     * "container": the container div of the entire menu
     * "menu-title": the &lt;a> element containing the menu title
-    * "menu-icon": the icon next to the menu title
-    * "nav": the &lt;ul> containing "nav-link"
+    * "menu-icon": the &lt;i> element containing the icon next to the menu
+    * "nav": the &lt;ul> containing all "nav-item" elements
     * "nav-item": the &lt;li> element containing "nav-link"
-    * "nav-link": the &lt;a> element containing the text of each option
-    * "nav-link-selected": the &lt;a> element containing the text of the selected option
-    * "nav-link-text": the &lt;p> text-only element contained in any nav-link
-    * "icon": the icon next to each option
+    * "nav-link": all &lt;a> elements containing the text and icon of each option item
+    * "nav-link-selected": the &lt;a> element containing the text and icon of the selected option
+    * "nav-link-text": all &lt;p> text-only element contained in any nav-link
+    * "nav-link-text-selected": the &lt;p> text-only element in the selected option item
+    * "option-icon": all &lt;i> elements containing the icons for each option item
+    * "option-icon-selected": the &lt;i> element containing only the selected option items icon
+    * "icon": all icons, and the menu icon and every option item icon
     * "separator": the &lt;hr> element separating the options
 - manual_select: Pass to manually change the menu item selection.
 The function returns the (string) option currently selected
@@ -108,3 +111,10 @@ Install python module locally: `pip install -e .`
 
 Build the component frontend and enter the example/test environment:
 `npm run build --prefix ./frontend && TDEBUG=1 ./__init__.py`
+
+
+OR Watch the component for code changes:
+`npm run serve --prefix ./frontend`
+
+Then enter the example/test environment:
+`TDEBUG=1 ./__init__.py`

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ The `option_menu` function accepts the following parameters:
 - manual_select: Pass to manually change the menu item selection.
 The function returns the (string) option currently selected
 - on_change: A callback that will happen when the selection changes. The callback function should accept one argument "key". You can use it to fetch the value of the menu (see [example 5](#examples))
+- disabled: A boolean that will disable the menu buttons when True. The same as the disabled option on many native streamlit components.
 
 
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ The `option_menu` function accepts the following parameters:
 - manual_select: Pass to manually change the menu item selection.
 The function returns the (string) option currently selected
 - on_change: A callback that will happen when the selection changes. The callback function should accept one argument "key". You can use it to fetch the value of the menu (see [example 5](#examples))
-- disabled: A boolean that will disable the menu buttons when True. The same as the disabled option on many native streamlit components.
+- disabled: A boolean that will disable and grey the menu and options when `True`. The same as the disabled option on many native streamlit components.
 
 
 

--- a/README.md
+++ b/README.md
@@ -98,3 +98,11 @@ selected5 = option_menu(None, ["Home", "Upload", "Tasks", 'Settings'],
                         on_change=on_change, key='menu_5', orientation="horizontal")
 selected5
 ```
+
+
+#### Development
+
+Install python module locally: `pip install -e .`
+
+Build the component frontend and enter the example/test environment:
+`npm run build --prefix ./frontend && TDEBUG=1 ./__init__.py`

--- a/README.md
+++ b/README.md
@@ -29,14 +29,14 @@ The `option_menu` function accepts the following parameters:
     * "menu-title": the &lt;a> element containing the menu title
     * "menu-icon": the &lt;i> element containing the icon next to the menu
     * "nav": the &lt;ul> containing all "nav-item" elements
-    * "nav-item": the &lt;li> element containing "nav-link"
+    * "nav-item": the &lt;li> element containing "nav-link" for the option item
     * "nav-link": all &lt;a> elements containing the text and icon of each option item
-    * "nav-link-selected": the &lt;a> element containing the text and icon of the selected option
-    * "nav-link-text": all &lt;p> text-only element contained in any nav-link
-    * "nav-link-text-selected": the &lt;p> text-only element in the selected option item
+    * "nav-link-selected": the &lt;a> element containing the text and icon of the selected option item
+    * "nav-link-text": all &lt;p> text-only element contained in any "nav-link" element
+    * "nav-link-text-selected": the &lt;p> text-only element of the selected option item
     * "option-icon": all &lt;i> elements containing the icons for each option item
-    * "option-icon-selected": the &lt;i> element containing only the selected option items icon
-    * "icon": all icons, and the menu icon and every option item icon
+    * "option-icon-selected": the &lt;i> element containing only the icon for the selected option item
+    * "icon": all icons, the menu icon and every option item icon
     * "separator": the &lt;hr> element separating the options
 - manual_select: Pass to manually change the menu item selection.
 The function returns the (string) option currently selected

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ The `option_menu` function accepts the following parameters:
     * "nav-item": the &lt;li> element containing "nav-link"
     * "nav-link": the &lt;a> element containing the text of each option
     * "nav-link-selected": the &lt;a> element containing the text of the selected option
+    * "nav-link-text": the &lt;p> text-only element contained in any nav-link
     * "icon": the icon next to each option
     * "separator": the &lt;hr> element separating the options
 - manual_select: Pass to manually change the menu item selection.

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The `option_menu` function accepts the following parameters:
 - manual_select: Pass to manually change the menu item selection.
 The function returns the (string) option currently selected
 - on_change: A callback that will happen when the selection changes. The callback function should accept one argument "key". You can use it to fetch the value of the menu (see [example 5](#examples))
-
+- disabled: A boolean that will disable the menu buttons when True. The same as the disabled option on many native streamlit components.
 
 
 ### Manual Selection

--- a/streamlit_option_menu/__init__.py
+++ b/streamlit_option_menu/__init__.py
@@ -44,7 +44,7 @@ def option_menu(
     manual_select=None,
     key=None,
     on_change=None,
-    disabled: bool = False,
+    disabled=False,
 ):
     """_summary_
 
@@ -59,6 +59,7 @@ def option_menu(
         manual_select (_type_, optional): An index to select. If passed, will change current selection to the passsed.
         key (_type_, optional): The component key. Defaults to None.
         on_change (_type_, optional): A callback function to call when the selection changes. Defaults to None. The callback function must accept a single argument, which will be the key of the option menu. You can fetch current selection by calling st.session_state[key]
+        disabled (_type_, optional): A boolean that will disable the menu buttons when True. The same as the disabled option on many native streamlit components.
 
     Returns:
         str: The selected option

--- a/streamlit_option_menu/__init__.py
+++ b/streamlit_option_menu/__init__.py
@@ -4,7 +4,7 @@ import streamlit.components.v1 as components
 from streamlit_option_menu.streamlit_callback import register_callback
 import os
 
-_RELEASE = os.getenv("TDEBUG", None) or True
+_RELEASE = not os.getenv("TDEBUG", None)
 
 # Declare a Streamlit component. `declare_component` returns a function
 # that is used to create instances of the component. We're naming this

--- a/streamlit_option_menu/__init__.py
+++ b/streamlit_option_menu/__init__.py
@@ -25,8 +25,7 @@ if not _RELEASE:
 else:
     parent_dir = os.path.dirname(os.path.abspath(__file__))
     build_dir = os.path.join(parent_dir, "frontend/dist")
-    _component_func = components.declare_component(
-        "option_menu", path=build_dir)
+    _component_func = components.declare_component("option_menu", path=build_dir)
 
 # Create a wrapper function for the component. This is an optional
 # best practice - we could simply expose the component function returned by
@@ -35,8 +34,18 @@ else:
 # output value, and add a docstring for users.
 
 
-def option_menu(menu_title, options, default_index=0, menu_icon=None, icons=None, orientation="vertical",
-                styles=None, manual_select=None, key=None, on_change=None):
+def option_menu(
+    menu_title,
+    options,
+    default_index=0,
+    menu_icon=None,
+    icons=None,
+    orientation="vertical",
+    styles=None,
+    manual_select=None,
+    key=None,
+    on_change=None,
+):
     """_summary_
 
     Args:
@@ -56,18 +65,29 @@ def option_menu(menu_title, options, default_index=0, menu_icon=None, icons=None
     """
     if on_change is not None:
         if key is None:
-            st.error("You must pass a key if you want to use the on_change callback for the option menu")
-        else:    
+            st.error(
+                "You must pass a key if you want to use the on_change callback for the option menu"
+            )
+        else:
             register_callback(key, on_change, key)
-    
-    if manual_select is not None and key is None:  
+
+    if manual_select is not None and key is None:
         default_index = manual_select
-        
-    component_value = _component_func(options=options, 
-                key=key, defaultIndex=default_index, icons=icons, menuTitle=menu_title, 
-                menuIcon=menu_icon, default=options[default_index], 
-                orientation=orientation, styles=styles, manualSelect=manual_select)
+
+    component_value = _component_func(
+        options=options,
+        key=key,
+        defaultIndex=default_index,
+        icons=icons,
+        menuTitle=menu_title,
+        menuIcon=menu_icon,
+        default=options[default_index],
+        orientation=orientation,
+        styles=styles,
+        manualSelect=manual_select,
+    )
     return component_value
+
 
 # Create a second instance of our component whose `name` arg will vary
 # based on a text_input widget.
@@ -80,22 +100,41 @@ def option_menu(menu_title, options, default_index=0, menu_icon=None, icons=None
 if __name__ == "__main__":
     st.set_page_config(page_title="Option Menu", layout="wide")
     with st.sidebar:
-        selected = option_menu("Main Menu", ["Home", "Upload","---", "Tasks", 'Settings'], 
-        icons=['house', 'cloud-upload', None, "list-task", 'gear'], menu_icon="cast", default_index=1)
+        selected = option_menu(
+            "Main Menu",
+            ["Home", "Upload", "---", "Tasks", "Settings"],
+            icons=["house", "cloud-upload", None, "list-task", "gear"],
+            menu_icon="cast",
+            default_index=1,
+        )
 
-    selected2 = option_menu(None, ["Home", "Upload", "---", "Tasks", 'Settings'], 
-        icons=['house', 'cloud-upload', None, "list-task", 'gear'], 
-        menu_icon="cast", default_index=0, orientation="horizontal")
+    selected2 = option_menu(
+        None,
+        ["Home", "Upload", "---", "Tasks", "Settings"],
+        icons=["house", "cloud-upload", None, "list-task", "gear"],
+        menu_icon="cast",
+        default_index=0,
+        orientation="horizontal",
+    )
 
-    selected3 = option_menu(None, ["Home", "Upload",  "Tasks", 'Settings'], 
-        icons=['house', 'cloud-upload', "list-task", 'gear'], 
-        menu_icon="cast", default_index=0, orientation="horizontal",
+    selected3 = option_menu(
+        None,
+        ["Home", "Upload", "Tasks", "Settings"],
+        icons=["house", "cloud-upload", "list-task", "gear"],
+        menu_icon="cast",
+        default_index=0,
+        orientation="horizontal",
         styles={
             "container": {"padding": "0!important", "background-color": "#fafafa"},
-            "icon": {"color": "orange", "font-size": "25px"}, 
-            "nav-link": {"font-size": "25px", "text-align": "left", "margin":"0px", "--hover-color": "#eee"},
+            "icon": {"color": "orange", "font-size": "25px"},
+            "nav-link": {
+                "font-size": "25px",
+                "text-align": "left",
+                "margin": "0px",
+                "--hover-color": "#eee",
+            },
             "nav-link-selected": {"background-color": "green"},
-        }
+        },
     )
 
     disabled_menu_example = option_menu(

--- a/streamlit_option_menu/__init__.py
+++ b/streamlit_option_menu/__init__.py
@@ -1,9 +1,10 @@
+#!/usr/bin/env -S streamlit run
 import streamlit as st
 import streamlit.components.v1 as components
 from streamlit_option_menu.streamlit_callback import register_callback
 import os
 
-_RELEASE = True
+_RELEASE = os.getenv("TDEBUG", None) or True
 
 # Declare a Streamlit component. `declare_component` returns a function
 # that is used to create instances of the component. We're naming this
@@ -17,6 +18,7 @@ _RELEASE = True
 # best practice.
 
 if not _RELEASE:
+    disabled = True
     _component_func = components.declare_component(
         "option_menu",
         url="http://localhost:3001",

--- a/streamlit_option_menu/__init__.py
+++ b/streamlit_option_menu/__init__.py
@@ -173,7 +173,7 @@ if __name__ == "__main__":
             "icon": {"color": "orange", "font-size": "25px"}, # Overrides menu-icon and option-icon unless !important
             "menu-icon": {"color": "purple !important", "font-size": "14px"},
             "option-icon": {"color": "blue !important", "font-size": "10px !important"},
-            "option-icon-selected": {"color": "lightblue", "font-size": "14px"},
+            "option-icon-selected": {"color": "lightblue", "font-size": "50px !important"},
             "nav-link": {
                 "font-size": "25px",
                 "text-align": "left",

--- a/streamlit_option_menu/__init__.py
+++ b/streamlit_option_menu/__init__.py
@@ -160,3 +160,28 @@ if __name__ == "__main__":
         },
         disabled=True,
     )
+
+    style_menu_example = option_menu(
+        "Styling",
+        ["Home", "Somewhere"],
+        icons=["house", "gear"],
+        menu_icon="cast",
+        default_index=0,
+        orientation="horizontal",
+        styles={
+            "container": {"padding": "0!important", "background-color": "#fafafa"},
+            "icon": {"color": "orange", "font-size": "25px"}, # Overrides menu-icon and option-icon unless !important
+            "menu-icon": {"color": "purple !important", "font-size": "14px"},
+            "option-icon": {"color": "blue !important", "font-size": "10px !important"},
+            "option-icon-selected": {"color": "lightblue", "font-size": "14px"},
+            "nav-link": {
+                "font-size": "25px",
+                "text-align": "left",
+                "margin": "0px",
+                "--hover-color": "#eee",
+            },
+            "nav-link-selected": {"background-color": "green"},
+            "nav-link-text": {"color": "rgba(100, 100, 100)"},
+            "nav-link-text-selected": {"color": "indigo !important", "filter": "brightness(80%)"},
+        },
+    )

--- a/streamlit_option_menu/__init__.py
+++ b/streamlit_option_menu/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S streamlit run
+#!/usr/bin/env -S streamlit run --server.runOnSave True
 import streamlit as st
 import streamlit.components.v1 as components
 from streamlit_option_menu.streamlit_callback import register_callback
@@ -18,7 +18,6 @@ _RELEASE = os.getenv("TDEBUG", None) or True
 # best practice.
 
 if not _RELEASE:
-    disabled = True
     _component_func = components.declare_component(
         "option_menu",
         url="http://localhost:3001",
@@ -139,4 +138,25 @@ if __name__ == "__main__":
             },
             "nav-link-selected": {"background-color": "green"},
         },
+    )
+
+    disabled = option_menu(
+        "Disabled Menu",
+        ["Home", "Unavailable", "Elsewhere"],
+        icons=["house", "gear", "list-task"],
+        menu_icon="cast",
+        default_index=0,
+        orientation="horizontal",
+        styles={
+            "container": {"padding": "0!important", "background-color": "#fafafa"},
+            "icon": {"color": "orange", "font-size": "25px"},
+            "nav-link": {
+                "font-size": "25px",
+                "text-align": "left",
+                "margin": "0px",
+                "--hover-color": "#eee",
+            },
+            "nav-link-selected": {"background-color": "green"},
+        },
+        disabled=True,
     )

--- a/streamlit_option_menu/__init__.py
+++ b/streamlit_option_menu/__init__.py
@@ -140,7 +140,7 @@ if __name__ == "__main__":
         },
     )
 
-    disabled = option_menu(
+    disabled_menu_example = option_menu(
         "Disabled Menu",
         ["Home", "Unavailable", "Elsewhere"],
         icons=["house", "gear", "list-task"],

--- a/streamlit_option_menu/__init__.py
+++ b/streamlit_option_menu/__init__.py
@@ -60,7 +60,7 @@ def option_menu(
         manual_select (_type_, optional): An index to select. If passed, will change current selection to the passsed.
         key (_type_, optional): The component key. Defaults to None.
         on_change (_type_, optional): A callback function to call when the selection changes. Defaults to None. The callback function must accept a single argument, which will be the key of the option menu. You can fetch current selection by calling st.session_state[key]
-        disabled (_type_, optional): A boolean that will disable the menu buttons when True. The same as the disabled option on many native streamlit components.
+        disabled (_type_, optional): A boolean that will disable and grey the menu and options when `True`. The same as the disabled option on many native streamlit components.
 
     Returns:
         str: The selected option

--- a/streamlit_option_menu/__init__.py
+++ b/streamlit_option_menu/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S streamlit run --server.runOnSave True
+#!/usr/bin/env -S streamlit run
 import streamlit as st
 import streamlit.components.v1 as components
 from streamlit_option_menu.streamlit_callback import register_callback
@@ -45,6 +45,7 @@ def option_menu(
     manual_select=None,
     key=None,
     on_change=None,
+    disabled=False,
 ):
     """_summary_
 
@@ -59,6 +60,7 @@ def option_menu(
         manual_select (_type_, optional): An index to select. If passed, will change current selection to the passsed.
         key (_type_, optional): The component key. Defaults to None.
         on_change (_type_, optional): A callback function to call when the selection changes. Defaults to None. The callback function must accept a single argument, which will be the key of the option menu. You can fetch current selection by calling st.session_state[key]
+        disabled (_type_, optional): A boolean that will disable the menu buttons when True. The same as the disabled option on many native streamlit components.
 
     Returns:
         str: The selected option
@@ -85,6 +87,7 @@ def option_menu(
         orientation=orientation,
         styles=styles,
         manualSelect=manual_select,
+        disabled=disabled,
     )
     return component_value
 

--- a/streamlit_option_menu/frontend/src/MyComponent.vue
+++ b/streamlit_option_menu/frontend/src/MyComponent.vue
@@ -2,24 +2,27 @@
     <div class="menu">
         <div class="container-xxl d-flex flex-column flex-shrink-0" :class="{'p-3': !isHorizontal, 'p-h':isHorizontal, 'nav-justified': isHorizontal}" :style="styleObjectToString(styles['container'])">
             <template v-if="menuTitle">
-                <a href="#" class="menu-title align-items-center mb-md-0 me-md-auto text-decoration-none"
-                :style="styleObjectToString(styles['menu-title'])"
+                <a href="#"
+                   class="menu-title align-items-center mb-md-0 me-md-auto text-decoration-none"
+                   :style="styleObjectToString(styles['menu-title'])"
                 >
                     <i class="icon" :class="menuIcon" :style="styleObjectToString(styles['menu-icon'])"></i>
                     {{menuTitle}}
                 </a>
             <hr>
             </template>
-            <ul class="nav nav-pills mb-auto" :class="{'flex-column': !isHorizontal, 'nav-justified': isHorizontal}"
-            :style="styleObjectToString(styles['nav'])"
+            <ul class="nav nav-pills mb-auto"
+               :class="{'flex-column': !isHorizontal, 'nav-justified': isHorizontal}"
+               :style="styleObjectToString(styles['nav'])"
             >
                 <li class="nav-item" v-for="(option,i) in args.options" :key="option"
                 :style="styleObjectToString(styles['nav-item'])"
                 >
                     <hr :class="{vr: isHorizontal}" v-if="option === '---'" :style="styleObjectToString(styles['separator'])">
                     <a v-else href="javascript:void(0);" class="nav-link" :class="{active: i == selectedIndex, 'nav-link-horizontal':isHorizontal}"
-                    @click="onClicked(i, option)" aria-current="page"
-                    :style="styleObjectToString(styles['nav-link']) + styleObjectToString(styles['nav-link-selected'], i == selectedIndex)">
+                       @click="onClicked(i, option)" aria-current="page"
+                       :style="styleObjectToString(styles['nav-link']) + styleObjectToString(styles['nav-link-selected'], i == selectedIndex)"
+                    >
                         <i class="icon" :class="icons[i]" :style="styleObjectToString(styles['icon'])"></i>
                         <p class="nav-link-text" :style="styleObjectToString(styles['nav-link-text'])">{{option}}</p>
                     </a>
@@ -28,6 +31,7 @@
         </div>
     </div>
 </template>
+
 <script>
 import { ref, watch } from "vue"
 import { Streamlit } from "streamlit-component-lib"
@@ -45,6 +49,8 @@ export default {
     props: ["args"], // Arguments that are passed to the plugin in Python are accessible in prop "args"
     setup(props) {
         useStreamlit() // lifecycle hooks for automatic Streamlit resize
+
+        // const manualSelect = props.args.manualSelect === undefined || props.args.manualSelect === null ? NaN : props.args.manualSelect;
 
         const disabled = ref(props.args.disabled)
         const menuTitle = ref(props.args.menuTitle)
@@ -76,6 +82,16 @@ export default {
             selectedIndex.value = index
             Streamlit.setComponentValue(option)
         }
+
+        const triggerMenuClick = (index) => {
+            console.log("chosen index is: ", index)
+            if (index >= 0 && index < props.args.options.length) {
+                onClicked(index, props.args.options[index]);
+            } else {
+                console.warn('Invalid index for triggerMenuClick');
+            }
+        }
+
         const styleObjectToString = (obj, condition) => {
             if (typeof condition === "undefined") {
                 condition = true
@@ -119,17 +135,6 @@ export default {
         }
         const finalStyles = calcStyles()
         const styles = ref(finalStyles);
-
-        // const manualSelect = props.args.manualSelect === undefined || props.args.manualSelect === null ? NaN : props.args.manualSelect;
-
-        const triggerMenuClick = (index) => {
-            console.log("chosen index is: ", index)
-            if (index >= 0 && index < props.args.options.length) {
-                onClicked(index, props.args.options[index]);
-            } else {
-                console.warn('Invalid index for triggerMenuClick');
-            }
-        }
 
         watch(
             () => props.args.icons,

--- a/streamlit_option_menu/frontend/src/MyComponent.vue
+++ b/streamlit_option_menu/frontend/src/MyComponent.vue
@@ -265,6 +265,10 @@ export default {
     height: 80%;
 }
 
+.nav {
+    align-items: center;
+}
+
 .nav-link {
     display: flex;
     align-items: center;

--- a/streamlit_option_menu/frontend/src/MyComponent.vue
+++ b/streamlit_option_menu/frontend/src/MyComponent.vue
@@ -264,4 +264,13 @@ export default {
     width: 1px;
     height: 80%;
 }
+
+.nav-link {
+    display: flex;
+    align-items: center;
+}
+
+.nav-link-text {
+    margin: 0;
+}
 </style>

--- a/streamlit_option_menu/frontend/src/MyComponent.vue
+++ b/streamlit_option_menu/frontend/src/MyComponent.vue
@@ -1,12 +1,14 @@
 <template>
     <div class="menu">
-        <div class="container-xxl d-flex flex-column flex-shrink-0" :class="{'p-3': !isHorizontal, 'p-h':isHorizontal, 'nav-justified': isHorizontal}" :style="styleObjectToString(styles['container'])">
+        <div class="container-xxl d-flex flex-column flex-shrink-0"
+            :class="{'p-3': !isHorizontal, 'p-h':isHorizontal, 'nav-justified': isHorizontal}"
+            :style="styleObjectToString(styles['container'])">
             <template v-if="menuTitle">
                 <a href="#"
                    class="menu-title align-items-center mb-md-0 me-md-auto text-decoration-none"
                    :style="styleObjectToString(styles['menu-title'])"
                 >
-                    <i class="icon" :class="menuIcon" :style="styleObjectToString(styles['menu-icon'])"></i>
+                    <i class="icon" :class="menuIcon" :style="styleObjectToString(styles['icon']) + styleObjectToString(styles['menu-icon'])"></i>
                     {{menuTitle}}
                 </a>
             <hr>
@@ -19,12 +21,16 @@
                 :style="styleObjectToString(styles['nav-item'])"
                 >
                     <hr :class="{vr: isHorizontal}" v-if="option === '---'" :style="styleObjectToString(styles['separator'])">
-                    <a v-else href="javascript:void(0);" class="nav-link" :class="{active: i == selectedIndex, 'nav-link-horizontal':isHorizontal}"
+                    <a v-else href="javascript:void(0);"
+                       class="nav-link"
+                       :class="{active: i == selectedIndex, 'nav-link-horizontal':isHorizontal}"
                        @click="onClicked(i, option)" aria-current="page"
                        :style="styleObjectToString(styles['nav-link']) + styleObjectToString(styles['nav-link-selected'], i == selectedIndex)"
                     >
-                        <i class="icon" :class="icons[i]" :style="styleObjectToString(styles['icon'])"></i>
-                        <p class="nav-link-text" :style="styleObjectToString(styles['nav-link-text'])">{{option}}</p>
+                        <i class="icon option-icon" :class="[icons[i], i == selectedIndex ? 'option-icon-selected' : '']"
+                            :style="styleObjectToString(styles['icon']) + styleObjectToString(styles['option-icon']) + styleObjectToString(styles['option-icon-selected'], i == selectedIndex)"></i>
+                        <p class="nav-link-text" :class="[i == selectedIndex ? 'nav-link-text-selected' : '']"
+                            :style="styleObjectToString(styles['nav-link-text']) + styleObjectToString(styles['nav-link-text-selected'], i == selectedIndex)">{{option}}</p>
                     </a>
                 </li>
             </ul>
@@ -131,6 +137,7 @@ export default {
                 for (const [tag, value] of Object.entries(cssProps))
                     finalStyles[elementKey][tag] = value
             }
+            console.log("styles", finalStyles)
             return finalStyles
         }
         const finalStyles = calcStyles()

--- a/streamlit_option_menu/streamlit_callback.py
+++ b/streamlit_option_menu/streamlit_callback.py
@@ -34,4 +34,8 @@ def register_callback(element_key, callback, *callback_args, **callback_kwargs):
         _state._components_callbacks = {}
 
     # Register a callback for a given element_key.
-    _state._components_callbacks[element_key] = (callback, callback_args, callback_kwargs)
+    _state._components_callbacks[element_key] = (
+        callback,
+        callback_args,
+        callback_kwargs,
+    )


### PR DESCRIPTION
Continuation of previous PR with styling issues fixed: 
https://github.com/victoryhb/streamlit-option-menu/pull/49

Please review @victoryhb 

![image](https://github.com/victoryhb/streamlit-option-menu/assets/45532845/3d6a335b-e87c-4cd3-8c10-7a92f4d1cec4)


I have updated the CSS to use an invert() filter so the colour will be visible (but faded) on various surroundings.
