### PR TITLE
Solve issue with manual select not working

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,9 +78,12 @@ selected3 = option_menu(None, ["Home", "Upload",  "Tasks", 'Settings'],
 # 4. Manual Item Selection
 option_list = ["Home", "Upload", "Tasks", 'Settings']
 manual_select = None
-if st.session_state.get('switch_button', False):
+if st.session_state.get('menu_4', False):
     option_list_option = st.session_state['switch_button']
-    manual_select = option_list.index(option_list_option)
+    manual_select = option_list.index(option_list_option) # The manual select is the index of the list in the options
+
+if st.session_state.get('switch_button',False) and manual_select: # Check if the button was pressed and move it to the next option
+    manual_select = (manual_select + 1) % 4
     
 selected4 = option_menu(None, option_list, 
     icons=['house', 'cloud-upload', "list-task", 'gear'], 

--- a/README.md
+++ b/README.md
@@ -76,13 +76,13 @@ selected3 = option_menu(None, ["Home", "Upload",  "Tasks", 'Settings'],
 )
 
 # 4. Manual Item Selection
+option_list = ["Home", "Upload", "Tasks", 'Settings']
+manual_select = None
 if st.session_state.get('switch_button', False):
-    st.session_state['menu_option'] = (st.session_state.get('menu_option',0) + 1) % 4
-    manual_select = st.session_state['menu_option']
-else:
-    manual_select = None
+    option_list_option = st.session_state['switch_button']
+    manual_select = option_list.index(option_list_option)
     
-selected4 = option_menu(None, ["Home", "Upload", "Tasks", 'Settings'], 
+selected4 = option_menu(None, option_list, 
     icons=['house', 'cloud-upload', "list-task", 'gear'], 
     orientation="horizontal", manual_select=manual_select, key='menu_4')
 st.button(f"Move to Next {st.session_state.get('menu_option',1)}", key='switch_button')

--- a/streamlit_option_menu/__init__.py
+++ b/streamlit_option_menu/__init__.py
@@ -59,7 +59,7 @@ def option_menu(menu_title, options, default_index=0, menu_icon=None, icons=None
         else:    
             register_callback(key, on_change, key)
     
-    if manual_select is not None and key is None:  
+    if manual_select is not None:  
         default_index = manual_select
         
     component_value = _component_func(options=options, 


### PR DESCRIPTION
We were having an issue that the manual select wasn't working when we were using streamlit option menu, even when we copied the example in the readme it wasn't working.

We entered the code of the package to understand how it was working and found that the issue was related with the the if statement that checked if the key was None. To have the manual select you need to have the key set otherwise you can't use it.

In this change I removed it, because there is already a check for the on_change which is essential for the manual select.

I also improved the readme to work better with the manual select. I think the change also answers the issue #46.

I haven't tested, but the error I was getting was similar to issue #27 and from the description I think it will solve it as well.