### PR TITLE
fix: adapt to the new internal api for custom components in streamlit==1.34.0

### DIFF
--- a/streamlit_option_menu/streamlit_callback.py
+++ b/streamlit_option_menu/streamlit_callback.py
@@ -1,5 +1,10 @@
 from streamlit import session_state as _state
-from streamlit.components.v1 import components as _components
+
+try:
+    # Internal API was changed in streamlit 1.34.0
+    from streamlit.components.v1 import custom_component as _components
+except ImportError:
+    from streamlit.components.v1 import components as _components
 
 
 def _patch_register_widget(register_widget):


### PR DESCRIPTION
After upgrading to streamlit==1.34.0 navigation breaks as the internal API changed for custom_components. 

Fix from comment: https://github.com/victoryhb/streamlit-option-menu/issues/70#issuecomment-2097913379

Fixes Issue #70: https://github.com/victoryhb/streamlit-option-menu/issues/70

Proper solution is to adapt to recent changes from streamlit added here: https://github.com/streamlit/streamlit/pull/8633/files#diff-0b9f0def23f70da63332cd57e36af71cbda61e133b0963f0a9f1103ccc759c11R151-R154